### PR TITLE
docs(readme): add installation instructions using uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 > [!NOTE]
 > 此项目为 [HITCourseHunter](https://github.com/AbyssSkb/HITCourseHunter) 的延续，旨在成为一个强大的命令行工具。
 
+## 安装教程
+
+> [!NOTE]
+> 请确保你已安装 [uv](https://docs.astral.sh/uv/getting-started/installation/)
+
+```bash
+uv tool install git+https://github.com/AbyssSkb/hch
+```
+
 ## 使用说明
 
 ```bash


### PR DESCRIPTION
Add clear instructions to the README.md showing how to install the tool using the uv package manager, with a note reminding users to install uv first.