### PR TITLE
fix: improve retry condition checks

### DIFF
--- a/src/hch/list/hunted.py
+++ b/src/hch/list/hunted.py
@@ -93,7 +93,6 @@ def main():
             except CookieExpiredError:
                 get_cookies(config)
                 retries += 1
-
         if time_info is None:
             raise MaxRetriesError()
 

--- a/src/hch/select.py
+++ b/src/hch/select.py
@@ -127,18 +127,16 @@ def main() -> None:
             except CookieExpiredError:
                 get_cookies(config)
                 retries += 1
-
         if time_info is None:
             raise MaxRetriesError()
 
         categories = None
-        while retries < config.max_retries and not categories:
+        while retries < config.max_retries and categories is None:
             try:
                 categories = get_course_categories(time_info, config.cookies)
             except CookieExpiredError:
                 get_cookies(config)
                 retries += 1
-
         if categories is None:
             raise MaxRetriesError()
 


### PR DESCRIPTION
Standardize retry condition checks by using `is None` consistently and remove unnecessary blank lines between retry loops and error handling.